### PR TITLE
Bug fix in CouchDBSessions

### DIFF
--- a/Sources/CouchDBSessions.swift
+++ b/Sources/CouchDBSessions.swift
@@ -24,7 +24,9 @@ public struct CouchDBSessions {
 		do {
 			do {
 				try proxy.find(["updated":["$lt": (Int(Date().timeIntervalSince1970) - SessionConfig.idle)]])
-				proxy.to(proxy.results.rows[0])
+                if proxy.results.rows.count > 0 {
+                    proxy.to(proxy.results.rows[0])
+                }
 			} catch {
 				print("Error retrieving session: \(error)")
 			}


### PR DESCRIPTION
On regular intervals CouchDBSessions crashes due to index out of range, easy to test by setting SessionConfig.idle = 20 and SessionConfig.purgeInterval = 10. Made a simple fix by checking proxy.results.rows.count before calling proxy.to(proxy.results.rows[0]).